### PR TITLE
Add Laravel 8.x support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
           - laravel: 9.*
             testbench: 7.*
           - laravel: 8.*
-            testbench: 6.5*
+            testbench: 6.5.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
           - laravel: 9.*
             testbench: 7.*
           - laravel: 8.*
-            testbench: 7.*
+            testbench: 6.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
           - laravel: 9.*
             testbench: 7.*
           - laravel: 8.*
-            testbench: 7.*
+            testbench: 6.5*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.composer/cache/files
           key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
           - laravel: 9.*
             testbench: 7.*
           - laravel: 8.*
-            testbench: 6.*
+            testbench: 7.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.composer/cache/files
           key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,12 +9,14 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.2, 8.1]
-        laravel: [10.*, 9.*]
+        laravel: [10.*, 9.*, 8.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 10.*
             testbench: 8.*
           - laravel: 9.*
+            testbench: 7.*
+          - laravel: 8.*
             testbench: 7.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}

--- a/README.md
+++ b/README.md
@@ -188,6 +188,11 @@ You can also enable [debugging mode](https://developers.google.com/analytics/dev
 ``` bash
 composer test
 ```
+or
+
+``` bash
+./vendor/bin/phpunit
+```
 
 ## Security
 

--- a/composer.json
+++ b/composer.json
@@ -33,10 +33,10 @@
     ],
     "require": {
         "php": "^8.1 || ^8.2",
-        "illuminate/bus": "^9.0 || ^10.0",
-        "illuminate/queue": "^9.0 || ^10.0",
-        "illuminate/http": "^9.0 || ^10.0",
-        "illuminate/validation": "^9.0 || ^10.0",
+        "illuminate/bus": "^8.0 || ^9.0 || ^10.0",
+        "illuminate/queue": "^8.0 || ^9.0 || ^10.0",
+        "illuminate/http": "^8.0 || ^9.0 || ^10.0",
+        "illuminate/validation": "^8.0 || ^9.0 || ^10.0",
         "guzzlehttp/guzzle": "^7.5"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,6 @@
         "php": "^8.1 || ^8.2",
         "illuminate/bus": "^8.0 || ^9.0 || ^10.0",
         "illuminate/queue": "^8.0 || ^9.0 || ^10.0",
-        "illuminate/http": "^9.0 || ^10.0",
         "illuminate/validation": "^8.0 || ^9.0 || ^10.0",
         "guzzlehttp/guzzle": "^7.5"
     },

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     "require-dev": {
         "mockery/mockery": "^1.4.4",
         "nesbot/carbon": "^2.66",
-        "orchestra/testbench": "^6.5 || ^7.0 || ^8.0",
+        "orchestra/testbench": "^6.20 || ^7.0 || ^8.0",
         "phpunit/phpunit": "^9.5"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     "require-dev": {
         "mockery/mockery": "^1.4.4",
         "nesbot/carbon": "^2.66",
-        "orchestra/testbench": "^6.0 || ^7.0 || ^8.0",
+        "orchestra/testbench": "^6.5 || ^7.0 || ^8.0",
         "phpunit/phpunit": "^9.5"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     "require-dev": {
         "mockery/mockery": "^1.4.4",
         "nesbot/carbon": "^2.66",
-        "orchestra/testbench": "^7.0 || ^8.0",
+        "orchestra/testbench": "^6.0 || ^7.0 || ^8.0",
         "phpunit/phpunit": "^9.5"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "php": "^8.1 || ^8.2",
         "illuminate/bus": "^8.0 || ^9.0 || ^10.0",
         "illuminate/queue": "^8.0 || ^9.0 || ^10.0",
-        "illuminate/http": "^8.0 || ^9.0 || ^10.0",
+        "illuminate/http": "^9.0 || ^10.0",
         "illuminate/validation": "^8.0 || ^9.0 || ^10.0",
         "guzzlehttp/guzzle": "^7.5"
     },

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "php": "^8.1 || ^8.2",
         "illuminate/bus": "^8.0 || ^9.0 || ^10.0",
         "illuminate/queue": "^8.0 || ^9.0 || ^10.0",
-        "illuminate/http": "^8.0 || ^9.0 || ^10.0",
+        "illuminate/http": "^8.74 || ^9.0 || ^10.0",
         "illuminate/validation": "^8.0 || ^9.0 || ^10.0",
         "guzzlehttp/guzzle": "^7.5"
     },

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "php": "^8.1 || ^8.2",
         "illuminate/bus": "^8.0 || ^9.0 || ^10.0",
         "illuminate/queue": "^8.0 || ^9.0 || ^10.0",
+        "illuminate/http": "^8.0 || ^9.0 || ^10.0",
         "illuminate/validation": "^8.0 || ^9.0 || ^10.0",
         "guzzlehttp/guzzle": "^7.5"
     },


### PR DESCRIPTION
Hi @LukeTowers

This PR includes support for laravel 8.0 version.
No `src` files are changed, only the composer dependencies to make it pass for laravel 8.x.