### PR TITLE
Fix PHP 8.4 deprecation warning by marking constructor parameters as explicitly nullable

### DIFF
--- a/src/Jobs/SendEventToAnalytics.php
+++ b/src/Jobs/SendEventToAnalytics.php
@@ -22,7 +22,7 @@ class SendEventToAnalytics implements ShouldQueue
 
     public ?string $sessionId;
 
-    public function __construct($event, string $clientId = null, string $userId = null, string $sessionId = null)
+    public function __construct($event, ?string $clientId = null, ?string $userId = null, ?string $sessionId = null)
     {
         $this->event = $event;
         $this->clientId = $clientId;


### PR DESCRIPTION
This PR resolves deprecation warnings introduced in PHP 8.4 due to implicitly nullable parameters in the `SendEventToAnalytics` job constructor.

**Before (deprecated in PHP 8.4):**

```
public function __construct($event, string $clientId = null, string $userId = null, string $sessionId = null)
```

**After (explicitly nullable):**

```
public function __construct($event, ?string $clientId = null, ?string $userId = null, ?string $sessionId = null)
```

This change preserves current behavior while ensuring compatibility with PHP 8.4.

Closes https://github.com/LukeTowers/laravel-ga4-event-tracking/issues/5

@LukeTowers — here's the fix we discussed for the PHP 8.4 deprecation warnings.
